### PR TITLE
Add some additional cells to explain the behavior of similarity

### DIFF
--- a/tour_model_eval/bins_clusters_confirmed_trips.ipynb
+++ b/tour_model_eval/bins_clusters_confirmed_trips.ipynb
@@ -7,17 +7,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from __future__ import unicode_literals\n",
-    "from __future__ import print_function\n",
-    "from __future__ import division\n",
-    "from __future__ import absolute_import\n",
-    "# Standard imports\n",
-    "from future import standard_library\n",
-    "standard_library.install_aliases()\n",
-    "from builtins import *\n",
-    "import math\n",
-    "import uuid as uu\n",
-    "import sys\n",
     "import logging\n",
     "\n",
     "# Our imports\n",
@@ -101,12 +90,62 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "departmental-article",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(len(trips))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "floating-morning",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "non_empty_trips = [t for t in trips if t[\"data\"][\"user_input\"] != {}]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "attended-earthquake",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "len(non_empty_trips), non_empty_trips"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "centered-particle",
    "metadata": {},
    "outputs": [],
    "source": [
     "sim = similarity.similarity(trips,radius)\n",
     "sim"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "senior-halifax",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(len(sim.data))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "generic-brighton",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(sim.data)"
    ]
   },
   {
@@ -123,14 +162,6 @@
     "    if user_input != None:\n",
     "        print(user_input,i)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "pending-warrant",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Notably:
- we read 66 trips
- only 1 has a user input
- we bin the trips
- `sim.data` only has 55 trips
    - this is also probably the problem with running all and above cutoff in the same notebook
- the 1 user input trip is among the 11 missing trips
- so we don't see any user inputs

Please retry with a different user

+ includes removal of unnecessary imports